### PR TITLE
BUGFIX: fixes relation id when save & publishing a new record

### DIFF
--- a/code/VersionedGridFieldDetailForm.php
+++ b/code/VersionedGridFieldDetailForm.php
@@ -145,6 +145,7 @@ class VersionedGridFieldDetailForm_ItemRequest extends GridFieldDetailForm_ItemR
 
 		$form->saveInto($record);
 		$record->write();
+		$this->gridField->getList()->add($record);
 		$record->publish("Stage", "Live");
 
 		$message = sprintf(


### PR DESCRIPTION
if you create a new record and click save & publish the relationship id isn't recorded in the model.
