### PR TITLE
fixing baseTable() function

### DIFF
--- a/code/VersionedGridFieldDetailForm.php
+++ b/code/VersionedGridFieldDetailForm.php
@@ -81,7 +81,7 @@ class VersionedGridFieldDetailForm_ItemRequest extends GridFieldDetailForm_ItemR
 	function baseTable() {
 		$record = $this->record;
 		$classes = ClassInfo::dataClassesFor($record->ClassName);
-		return array_pop($classes);
+		return array_shift($classes);
 	}
 
 	function canPublish() {


### PR DESCRIPTION
using `array_pop()` here will get the last element of `$classes` array, meaning 'the furthermost child class' instead of 'the furthermost ancestor class'. So the `isPublished()` function (which relies on `baseTable()`) delivers unpredictable results.

replacing by `array_shift()`, as it's also done in the related `baseTable()` function of `DataObject` class