### PR TITLE
BUGFIX: 3rd parameter of FormAction

### DIFF
--- a/code/VersionedGridFieldDetailForm.php
+++ b/code/VersionedGridFieldDetailForm.php
@@ -129,7 +129,7 @@ class VersionedGridFieldDetailForm_ItemRequest extends GridFieldDetailForm_ItemR
 		if($this->isPublished() && $this->canPublish() && !$this->IsDeletedFromStage && $this->canDeleteFromLive()) {
 			// "unpublish"
 			$minorActions->push(
-				FormAction::create('doUnpublish', _t('SiteTree.BUTTONUNPUBLISH', 'Unpublish'), 'delete')
+				FormAction::create('doUnpublish', _t('SiteTree.BUTTONUNPUBLISH', 'Unpublish'))
 					->setUseButtonTag(true)->setDescription("Remove this {$classname} from the published site")
 					->addExtraClass('ss-ui-action-destructive')->setAttribute('data-icon', 'unpublish')
 			);
@@ -139,7 +139,7 @@ class VersionedGridFieldDetailForm_ItemRequest extends GridFieldDetailForm_ItemR
 			if($this->isPublished() && $this->canEdit())	{
 				// "rollback"
 				$minorActions->push(
-					FormAction::create('doRollback', 'Cancel draft changes', 'delete')
+					FormAction::create('doRollback', 'Cancel draft changes')
 						->setUseButtonTag(true)->setDescription(_t('SiteTree.BUTTONCANCELDRAFTDESC', 'Delete your draft and revert to the currently published page'))
 				);
 			}


### PR DESCRIPTION
FormAction has been passed a 3rd parameter of "delete" which should be a Form instance.  This breaks 3.1.10 since a fix by @tractorcow  here https://github.com/silverstripe/silverstripe-framework/commit/1db08bac88f9330dc4e6dda1ae08628f245a5212#diff-47df5dc66a226683857b29a6ea330323R51 that correctly sets $form instead of using the 4th parameter that doesn't exist on FormField::__construct.