### PR TITLE
ENH add support for nested Versioned GridField's

### DIFF
--- a/code/VersionedGridFieldDetailForm.php
+++ b/code/VersionedGridFieldDetailForm.php
@@ -201,6 +201,20 @@ class VersionedGridFieldDetailForm_ItemRequest extends GridFieldDetailForm_ItemR
 	public function ItemEditForm() {
 		$form = parent::ItemEditForm();
 		$actions = $this->getCMSActions();
+        
+        // Support for nested Versioned GridField's
+		// Detect any GridFields, if managing a Versioned DataObject apply VersionedGridFieldDetailForm
+		foreach ($form->Fields()->dataFields() as $field) {
+			if ($field instanceof GridField) {
+				$class = $field->getList()->dataClass();
+				if ($class::has_extension("Versioned")) {
+					$config = $field->getConfig();
+					$config->removeComponentsByType('GridFieldDetailForm')
+						->addComponents(new VersionedGridFieldDetailForm());
+					$field->setConfig($config);
+				}
+			}
+		}
 
 		$form->setActions($actions);
 		return $form;


### PR DESCRIPTION
For example;

`Model A` and `Model B` are both versioned. `Model A` contains a `GridField` to manage `Model B` currently the VersionedGridFieldDetailForm isn't applied to the nested GridField