### PR TITLE
FIX: Avoid causing an error trying to create a singleton on an empty …

### DIFF
--- a/code/VersionedGridFieldDetailForm.php
+++ b/code/VersionedGridFieldDetailForm.php
@@ -185,9 +185,11 @@ class VersionedGridFieldDetailForm_ItemRequest extends GridFieldDetailForm_ItemR
 			if(method_exists($this->record, 'Link') && $this->record->Link()){
 
 				$subsiteString = '';
-				if(class_exists(Subsite::class) && singleton($this->owner->modelClass)->hasDatabaseField('SubsiteID')){
-					$subsiteString = '&SubsiteID=' . Subsite::currentSubsiteID();
-				}
+                if (class_exists(Subsite::class) &&
+                    $this->owner->modelClass &&
+                    singleton($this->owner->modelClass)->hasDatabaseField('SubsiteID')) {
+                    $subsiteString = '&SubsiteID=' . Subsite::currentSubsiteID();
+                }
 
 				$actions->push(
 					LiteralField::create('preview',


### PR DESCRIPTION
…argument.

modelClass attribute should be checked before passing it to the singleton function call as it is possible that it will be empty.